### PR TITLE
docs: add bootstrap docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ python3 -m http.server 8081
 # Open http://localhost:8081
 ```
 
+## Core Docs
+- `docs/product.md`
+- `docs/workflow.md`
+- `docs/architecture.md`
+
 ## Built With
 
 - Vanilla HTML/CSS/JS — no frameworks, no build step

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,28 @@
+# Architecture
+
+## Current structure
+The dashboard is intentionally lightweight:
+- `index.html` contains the UI, styling, and client-side behavior
+- `config.json` stores credit balance/configuration data
+- `activity-log.json` stores activity history displayed in the UI
+- `todo.json` stores the visible task backlog
+
+## Runtime model
+- static single-page app
+- no build step
+- served locally with a simple static file server or via GitHub Pages
+
+## Design intent
+The architecture favors:
+- low friction edits
+- easy inspection by humans and agents
+- fast local iteration
+- minimal operational dependency surface
+
+## Key tradeoff
+This simplicity makes the repo easy to bootstrap into, but it also means data contracts and UI logic live close together. If complexity grows materially, the repo may eventually need clearer module boundaries or a light build system.
+
+## Dependencies
+- modern browser runtime
+- JSON data files kept in sync with the intended dashboard state
+- GitHub Pages or a simple static server for hosting/viewing

--- a/docs/product.md
+++ b/docs/product.md
@@ -1,0 +1,28 @@
+# Product
+
+## Purpose
+`agent-dashboard` is The Depth's operational dashboard for monitoring multi-agent work.
+
+It exists to make team state legible at a glance: who is active, what work is moving, what it costs, and what still needs attention.
+
+## Primary users
+- Tony, as the primary operator and reviewer
+- Neil, as orchestration lead tracking delivery state
+- the rest of The Depth, as contributors aligning around shared status
+
+## Jobs to be done
+- show active, recent, and dormant agent work
+- surface task backlog and ownership clearly
+- make credit/cost usage visible
+- provide a fast operational view without requiring several separate tools
+
+## Current priorities
+- keep credits accuracy reliable
+- keep agent/task state easy to scan
+- preserve a lightweight, dependency-free deployment model
+- document the workflow so future agents can bootstrap into the repo cleanly
+
+## Non-goals
+- replacing GitHub as the durable source of truth for issues/PRs
+- becoming a heavy web app with a complex build stack unless the product truly needs it
+- hiding operational data behind opaque abstractions

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,29 @@
+# Workflow
+
+This repo covers the dashboard-specific workflow for The Depth's operational surface.
+
+## Canonical flow
+1. a dashboard need, bug, or improvement is identified
+2. the work is linked to a GitHub issue when durable/non-trivial
+3. the relevant data source or UI change is implemented in this repo
+4. changes are reviewed against the issue's acceptance criteria
+5. Homer validates QA when behavior changes
+6. Tony performs UAT when needed
+7. shipped behavior and durable lessons are reflected in repo docs/issues
+
+## Repo usage
+### Use this repo for
+- dashboard UI and behavior
+- local data files used by the dashboard
+- documentation about dashboard purpose, workflow, and architecture
+- dashboard-specific QA and iteration notes
+
+### Do not use this repo for
+- cross-project HQ workflow rules that belong in `depth-ops`
+- unrelated product experiments
+- chat-only status that should instead live in GitHub issues/PRs
+
+## Delivery expectations
+- meaningful changes should link back to an issue
+- product/behavior changes should include validation notes in the PR
+- docs should be kept current when the dashboard's shape or operating expectations change


### PR DESCRIPTION
## Linked issue
- closes #1

## What changed
- added the bootstrap doc bundle for the repo
- linked the docs from `README.md`
- added `docs/product.md`
- added `docs/workflow.md`
- added `docs/architecture.md`

## How it was verified
- reviewed the repo diff locally
- confirmed the minimum bootstrap doc bundle now exists for this repo

## Risks / follow-ups
- there are unrelated local data-file changes in the working tree that were intentionally left out of this PR
