### PR TITLE
fix: check 'done' status before marking agent active (issue #5)

### DIFF
--- a/index.html
+++ b/index.html
@@ -939,6 +939,7 @@ function lastActiveForAgent(agentName) {
 function isActiveAgent(agentName) {
   const latest = lastActiveForAgent(agentName);
   if (!latest) return false;
+  if (latest.status === 'done') return false;
   return (Date.now() - new Date(latest.timestamp)) < 3600000;
 }
 
@@ -1133,7 +1134,7 @@ function renderAgentStrip() {
     const entries = getAgentLog(a.name);
     const sorted = [...entries].sort((x,y) => new Date(y.timestamp) - new Date(x.timestamp));
     const latest = sorted[0] || null;
-    const isActive = latest ? (Date.now() - new Date(latest.timestamp)) < 3600000 : false;
+    const isActive = latest && latest.status !== 'done' ? (Date.now() - new Date(latest.timestamp)) < 3600000 : false;
 
     const currentTask = latest ? (latest.detail || latest.action || '—').substring(0, 40) + (latest.detail && latest.detail.length > 40 ? '…' : '') : 'No activity recorded';
     const costTotal = entries.reduce((s,e) => s + (e.cost_usd || 0), 0);
@@ -1239,8 +1240,9 @@ function renderActivity() {
   const dormantAgents = AGENTS.filter(a => {
     const agentLogs = _log.filter(e => e.agent === a.name);
     if (!agentLogs.length) return true;
-    const latest = Math.max(...agentLogs.map(e => new Date(e.timestamp)));
-    return (now - latest) > oneHour;
+    const latestEntry = [...agentLogs].sort((x,y) => new Date(y.timestamp) - new Date(x.timestamp))[0];
+    if (latestEntry.status === 'done') return true;
+    return (now - new Date(latestEntry.timestamp)) > oneHour;
   });
   const dormantEntries = dormantAgents.map(a => {
     const last = [..._log.filter(e => e.agent === a.name)].sort((x,y) => new Date(y.timestamp) - new Date(x.timestamp))[0];
@@ -1354,7 +1356,7 @@ function renderTeam() {
   grid.innerHTML = AGENTS.map(a => {
     const latest = lastActiveForAgent(a.name);
     const lastActive = latest ? timeAgo(latest.timestamp) : 'never';
-    const isActive = latest ? (Date.now() - new Date(latest.timestamp)) < 3600000 : false;
+    const isActive = latest && latest.status !== 'done' ? (Date.now() - new Date(latest.timestamp)) < 3600000 : false;
     return `<div class="team-card">
       <div class="team-card-top">
         <div class="team-avatar">${a.emoji}</div>


### PR DESCRIPTION
## Summary

- Previously, agent status was determined solely by how recent the last log entry was (< 1 hour = active)
- If an agent's latest log entry has `status: 'done'`, they should be Idle/Offline regardless of recency
- Fixes four code locations: `isActiveAgent`, `renderAgentStrip`, `renderTeam`, and `dormantAgents` in `renderActivity`

## Changes

| Location | Before | After |
|---|---|---|
| `isActiveAgent` | time-only check | returns `false` if `latest.status === 'done'` |
| `renderAgentStrip` `isActive` | time-only check | short-circuits on `status === 'done'` |
| `renderTeam` `isActive` | time-only check | short-circuits on `status === 'done'` |
| `dormantAgents` filter | time-only check | also marks dormant if `latest.status === 'done'` |

## Test plan

- [ ] Agent with a recent (< 1h) `done` entry shows as Idle/Offline in agent strip
- [ ] Agent with a recent `in-progress` entry still shows as Active
- [ ] Pulse strip active count excludes agents whose latest entry is `done`
- [ ] Activity tab dormant panel includes agents whose latest entry is `done`

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)